### PR TITLE
Mover Chronos Consulting a Recruiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Una lista con empresas para trabajar como desarrollador de software en Colombia.
 1. [BlueSoft Technology](http://www.bluesoft.com.co/html/oportunidades.html) (Bogotá)
 1. [Michael Page](https://www.michaelpage.com.co/job-search)
 1. [JellyJobs](https://jellyjob.com/empleo/) (Bogotá)
+1. [Chronos Consulting](https://www.chronosconsulting.com/job-offers/colombia/) (Bogotá, Cali)
 
 ## Empresas donde no se necesita saber ingles
 
@@ -156,7 +157,6 @@ No se sabe si son Nearshores, producto propio o si se necesita inglés.
 1. [Sofka](https://www.sofka.com.co/es/trabaja_con_nosotros_registro/) (Medellín)
 1. [CondorLabs](https://condorlabs.io/hiring) (Medellín, Cartagena)
 1. [KPMG](https://www.elempleo.com/sitios-empresariales/colombia/kpmg/oferta_sitio.asp?Actual=1) (Bogotá)
-1. [Chronos Consulting](https://www.chronosconsulting.com/job-offers/colombia/) (Bogotá, Cali)
 1. [Guarumo Mobile Technologies](https://www.linkedin.com/company/guarumo/jobs/) (Floridablanca)
 1. [Grupo-IMCLAN](https://www.linkedin.com/company/grupo-inclam/jobs/) (Medellín)
 1. [JSHeld](https://www.linkedin.com/company/j-s--held/jobs/) (Medellín)


### PR DESCRIPTION
En el _about us_(y otras partes dice):

> Yet, we work like a boutique recruitment agency