### PR TITLE
Eliminar Zebra Technologies de la lista de empresas

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,5 @@ No se sabe si son Nearshores, producto propio o si se necesita inglés.
 1. [JSHeld](https://www.linkedin.com/company/j-s--held/jobs/) (Medellín)
 1. [Extreme Technologies](https://www.linkedin.com/company/extreme-technologies-s-a-/jobs/) (Barranquilla)
 1. [Grupo CMC](https://www.linkedin.com/company/cmc-colombia/jobs/) (Bogotá)
-1. [Zebra Technologies](https://latinam-canada-zebra.icims.com/jobs/search?ss=1&searchLocation=13546--Bogota) (Bogotá)
 
 \* No se sabe si hay puestos para desarrollo de sofware o solo para consultoria en IT


### PR DESCRIPTION
Según su lista de oficinas [aquí](https://www.zebra.com/us/en/about-zebra/contact-zebra/global-locations.html) ya no están en Colombia.