### PR TITLE
Eliminada la empresa Grupo INCLAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,5 @@ No se sabe si son Nearshores, producto propio o si se necesita inglés.
 1. [Sofka](https://www.sofka.com.co/es/trabaja_con_nosotros_registro/) (Medellín)
 1. [CondorLabs](https://condorlabs.io/hiring) (Medellín, Cartagena)
 1. [KPMG](https://www.elempleo.com/sitios-empresariales/colombia/kpmg/oferta_sitio.asp?Actual=1) (Bogotá)
-1. [Chronos Consulting](https://www.chronosconsulting.com/job-offers/colombia/) (Bogotá, Cali)
-1. [Guarumo Mobile Technologies](https://www.linkedin.com/company/guarumo/jobs/) (Floridablanca)
-1. [Grupo-IMCLAN](https://www.linkedin.com/company/grupo-inclam/jobs/) (Medellín)
 
 \* No se sabe si hay puestos para desarrollo de sofware o solo para consultoria en IT


### PR DESCRIPTION
- Grupo INCLAM es una emprea de ingeniería civil de Madrid, tenían una oficina en Medellín donde estaban buscando desarrolladores pero las ofertas en LinkedIn ya no están y parece que lo eliminaron de su página.

- Chronos y Guaramo ya se movieron a sus respectivas secciones, están duplicadas.